### PR TITLE
docs: use foo and bar instead of first and second in 1-write-experiments tutorials

### DIFF
--- a/tutorials/1-write-experiments/2-many-steps.yaml
+++ b/tutorials/1-write-experiments/2-many-steps.yaml
@@ -11,15 +11,15 @@ workflows:
     parameters:
     - name: external
   steps:
-    first: hello
-    second: hello
+    foo: hello
+    bar: hello
   execute:
-    - target: <first>
+    - target: <foo>
       args:
         message: "from my parent workflow: %(external)s"
-    - target: <second>
+    - target: <bar>
       args:
-        message: "from my producer: <first>:output"
+        message: "from my producer: <foo>:output"
 
 
 components:

--- a/tutorials/1-write-experiments/4-read-step-outputs.yaml
+++ b/tutorials/1-write-experiments/4-read-step-outputs.yaml
@@ -11,15 +11,15 @@ workflows:
     parameters:
     - name: external
   steps:
-    first: writer
-    second: reader
+    foo: writer
+    bar: reader
   execute:
-    - target: <first>
+    - target: <foo>
       args:
         message: "%(external)s"
-    - target: <second>
+    - target: <bar>
       args:
-        file: "<first>/my_output.txt:ref"
+        file: "<foo>/my_output.txt:ref"
 
 components:
 - signature:


### PR DESCRIPTION


## Context


## Change list


- docs: use foo and bar instead of first and second in 1-write-experiments tutorials
- 
-

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
